### PR TITLE
update libubox

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,8 @@ OPTION(BUILD_LUA "build Lua plugin" ON)
 OPTION(BUILD_EXAMPLES "build examples" ON)
 
 INCLUDE(FindPkgConfig)
-PKG_SEARCH_MODULE(JSONC json-c)
-IF(JSONC_FOUND)
-  ADD_DEFINITIONS(-DJSONC)
-  INCLUDE_DIRECTORIES(${JSONC_INCLUDE_DIRS})
-ENDIF()
+PKG_SEARCH_MODULE(JSONC json-c REQUIRED)
+INCLUDE_DIRECTORIES(${JSONC_INCLUDE_DIRS})
 
 SET(SOURCES avl.c avl-cmp.c blob.c blobmsg.c uloop.c usock.c ustream.c ustream-fd.c vlist.c utils.c safe_list.c runqueue.c md5.c kvlist.c ulog.c base64.c udebug.c udebug-remote.c)
 

--- a/blobmsg_json.c
+++ b/blobmsg_json.c
@@ -17,11 +17,7 @@
 #include "blobmsg.h"
 #include "blobmsg_json.h"
 
-#ifdef JSONC
-	#include <json.h>
-#else
-	#include <json/json.h>
-#endif
+#include <json.h>
 
 bool blobmsg_add_object(struct blob_buf *b, json_object *obj)
 {

--- a/jshn.c
+++ b/jshn.c
@@ -13,12 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-#ifdef JSONC
-        #include <json.h>
-#else
-        #include <json/json.h>
-#endif
-
+#include <json.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/package/debian.changelog
+++ b/package/debian.changelog
@@ -1,3 +1,12 @@
+libubox (20250807) unstable; urgency=medium
+
+  Sync upstream
+  * udebug: fix issue with snapshot of remote ring
+  * udebug: remove obsolete debug message
+  * remove compatibility code for older json-c versions
+
+ -- Elektrobit  <info@elektrobit.com>  Thu, 07 Aug 2025 08:00:00 +0200
+
 libubox (20250206) unstable; urgency=medium
 
   * Update upstream (see upstream log) 

--- a/package/debian.libubox.dsc
+++ b/package/debian.libubox.dsc
@@ -2,9 +2,9 @@ Format: 3.0 (native)
 Source: libubox
 Binary: libubox1, libblobmsg-json1, libjson-script1, libubox-dev
 Architecture: any
-Version: 20250206
+Version: 20250807
 Maintainer: Elektrobit <info@elektrobit.de>
 Standards-Version: 4.5.0
 Build-Depends: cmake, debhelper (>= 9), libjson-c-dev, pkg-config
 Files:
- d1bd9c8e6cdc4290bcfa9eaa037688ed 142314 libubox_20250206.tar.gz
+ 00000000000000000000000000000000 0 libubox_20250807.tar.gz

--- a/udebug-remote.c
+++ b/udebug-remote.c
@@ -62,7 +62,6 @@ int udebug_remote_buf_map(struct udebug *ctx, struct udebug_remote_buf *rb, uint
 		return -1;
 
 	if (udebug_buf_open(&rb->buf, fd, msg->ring_size, msg->data_size)) {
-		fprintf(stderr, "failed to open fd %d, ring_size=%d, data_size=%d\n", fd, msg->ring_size, msg->data_size);
 		close(fd);
 		return -1;
 	}
@@ -134,6 +133,9 @@ rbuf_advance_read_head(struct udebug_remote_buf *rb, uint32_t head,
 			*data_start = u32_get(&ptr->start);
 			__sync_synchronize();
 		}
+
+		if (rb->head == head)
+			break;
 
 		if (ptr->timestamp > last_ptr->timestamp)
 			continue;


### PR DESCRIPTION
apply changes from b7acc8e6fd5e13611ad90a593e98f9589af4009a to 49056d178f42da98048a5d4c23f83a6f6bc6dd80 from the upstream

Summary:
- udebug: fix issue with snapshot of remote ring
- udebug: remove obsolete debug message
- remove compatibility code for older json-c versions