### PR TITLE
update libubox

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
 IF (BUILD_EXAMPLES)
     PROJECT(ubox-examples C)
     ADD_DEFINITIONS(-O1 -Wall -Werror --std=gnu99 -g3)

--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.6)
-
 PROJECT(uloop C)
 
 SET(CMAKE_INSTALL_PREFIX /)


### PR DESCRIPTION
update libubox
    apply changes for eeb6fcf914139a07bcd337cf90033239f1a8b1d1 to 61cc1e6fdc0eec075869e1d4d2e6e98c10856b97 from the upstream

    Summary:
    - examples: CMakeLists: drop redundant cmake_minimum_required
    - lua: CMakeLists: drop redundant cmake_minimum_required
    - lua: build: require CMake >= 3.10 due to dropped legacy support
    - examples: CMakeLists: update cmake minimum required version to 3.10
    
   